### PR TITLE
Up the version in beans.xml

### DIFF
--- a/cdi/cdi-j2se/src/main/resources/META-INF/beans.xml
+++ b/cdi/cdi-j2se/src/main/resources/META-INF/beans.xml
@@ -1,8 +1,8 @@
 
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0" bean-discovery-mode="all">
     <scan>
         <exclude name="org.jboss.weld.**" />
     </scan>


### PR DESCRIPTION
Hi, The [tutorial](http://www.mastertheboss.com/jboss-frameworks/cdi/building-a-cdi-2-standalone-java-application)  is about CDI 2 (not 1.1). 

Changing the beans.xml to reflect that :)